### PR TITLE
P6Spy should not report a noop span when failing to decorate.

### DIFF
--- a/src/test/java/io/opentracing/contrib/p6spy/JdbcTest.java
+++ b/src/test/java/io/opentracing/contrib/p6spy/JdbcTest.java
@@ -98,9 +98,19 @@ public class JdbcTest {
   }
 
   @Test
-  public void should_not_report_span_with_sql_exception() throws Exception {
+  public void should_report_span_with_sql_exception_on_decorate() throws Exception {
     final Connection connection = createConnection();
     Mockito.when(connection.getCatalog()).thenThrow(new SQLException());
+    simulateExecuteQuery(connection);
+
+    List<MockSpan> spans = mockTracer.finishedSpans();
+    assertEquals(1, spans.size());
+  }
+
+  @Test
+  public void should_not_report_span_with_sql_exception_on_url_analysis() throws Exception {
+    final Connection connection = createConnection();
+    Mockito.when(connection.getMetaData()).thenThrow(new SQLException());
     simulateExecuteQuery(connection);
 
     List<MockSpan> spans = mockTracer.finishedSpans();


### PR DESCRIPTION
P6Spy should not report a noop span when failing to decorate the already created scoped span. Otherwise, the system will not be able to close the already created span.